### PR TITLE
Wrap script in async function to fix "await is only valid in async functions" error

### DIFF
--- a/main.js
+++ b/main.js
@@ -1,3 +1,4 @@
+(async function(){
 var authorization = "Bearer ***"; // replace by authorization value
 var ua = navigator.userAgentData.brands.map(brand => `"${brand.brand}";v="${brand.version}"`).join(', ');
 var client_tid = "***"; // replace by X-Client-Transaction-Id value
@@ -640,3 +641,4 @@ else {
 }
 
 console.log("DELETION COMPLETE (if error happened before this may be not true)")
+})();


### PR DESCRIPTION
Fixes #30.

On Firefox (and maybe other browsers) the script currently gives an `Uncaught SyntaxError: await is only valid in async functions, async generators and modules` error when run. Wrapping the script in an async closure fixes this.